### PR TITLE
fix executable names with explicit architecture

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -2,10 +2,10 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $fileFullPath = Join-Path $toolsDir "$packageName.exe"
-$url = 'https://github.com/stedolan/jq/releases/download/jq-1.7/jq-win32.exe'
+$url = 'https://github.com/stedolan/jq/releases/download/jq-1.7/jq-windows-i386.exe'
 $checksumType = "sha256"
 $checksum = '9500d0300e28a930ab3430a101ca940038b8e82ca441f5c9a1fddaa9d1b770df'
-$url64 = 'https://github.com/stedolan/jq/releases/download/jq-1.7/jq-win64.exe'
+$url64 = 'https://github.com/stedolan/jq/releases/download/jq-1.7/jq-windows-amd64.exe'
 $checksumType64 = "sha256"
 $checksum64 = '2e9cc54d0a5d098e2007decec1dbb3c555ca2f5aabded7aec907fe0ffe401aab'
 


### PR DESCRIPTION
jq maintainers changed the executable name rule to support various CPU architectures.
Previously something like `jq-win32.exe` and `jq-win64.exe` but now `jq-windows-i386.exe` and `jq-windows-amd64.exe`.
They temporarily added the executable with old names to fix for the latest URLs (https://github.com/jqlang/jq/issues/2877).
But they might not retain the executable with the old names in the next release.